### PR TITLE
Add a download progress bar to the launcher.

### DIFF
--- a/progress.js
+++ b/progress.js
@@ -26,13 +26,15 @@ class Progress {
 
     _updateLabel() {
         // Cast to string before setting.
-        this._progress.attr("aria-valuenow", String(this.value));
-        this._progress.attr("aria-valuemax", String(this.max));
-        this._progressLabel.text(`${this.formattedValue()} of ${this.formattedMax()}`);
+        this._progress.setAttribute("aria-valuenow", String(this.value));
+        this._progress.setAttribute("aria-valuemax", String(this.max));
+
+        this._progressLabel.textContent =
+            `${this.formattedValue()} of ${this.formattedMax()}`;
     }
 
     _updateView() {
-        this._progressBar.css("width", `${(this.position * 100).toFixed(2)}%`);
+        this._progressBar.style.width = `${(this.position * 100).toFixed(2)}%`;
     }
 
     /**
@@ -40,33 +42,33 @@ class Progress {
      */
     get domTree() {
         if (!this._progress) {
-            // Only the container should be visible to ARIA. The contents should be
-            // hidden from assistive technologies.
-            const container = $("<div></div>").
-                attr("id", `progress-${this.name}`).
-                attr("role", "progressbar").
-                attr("aria-valuemin", "0").
-                attr("aria-valuetext", "Downloading...").
-                addClass("progress-bar");
+            // Only the container should be visible to ARIA. The contents should
+            // be hidden from assistive technologies.
+            const container = document.createElement("div");
+            container.setAttribute("id", `progress-${this.name}`);
+            container.setAttribute("role", "progressbar");
+            container.setAttribute("aria-valuemin", "0");
+            container.setAttribute("aria-valuetext", "Downloading...");
+            container.classList.add("progress-bar");
 
-            const bar = $("<div></div>").
-                attr("id", `progress-${this.name}-bar`).
-                attr("aria-hidden", "true").
-                addClass("progress-inner").
-                appendTo(container);
+            const bar = document.createElement("div");
+            bar.setAttribute("id", `progress-${this.name}-bar`);
+            bar.setAttribute("aria-hidden", "true");
+            bar.classList.add("progress-inner");
+            container.append(bar);
 
-            const label = $("<span></span>").
-                attr("id", `progress-${this.name}-label`).
-                attr("aria-hidden", "true").
-                addClass("progress-label").
-                appendTo(container);
+            const label = document.createElement("span");
+            label.setAttribute("id", `progress-${this.name}-label`);
+            label.setAttribute("aria-hidden", "true");
+            label.classList.add("progress-label");
+            container.append(label);
 
             this._progress = container;
             this._progressBar = bar;
             this._progressLabel = label;
         }
 
-        return this._progress.get(0);
+        return this._progress;
     }
 
     /** @type {number} */

--- a/progress.js
+++ b/progress.js
@@ -1,0 +1,145 @@
+/**
+ * Helper class for dealing with HTML progress bars.
+ */
+class Progress {
+  // We don't have to keep a permanent reference to the progress bar that we
+  // want; we can just run the constructor with the same name to get the same
+  // object out.
+  static progressBars = {};
+
+  /**
+   * `Progress :: String -> Progress`
+   * 
+   * Get a reference to a progress bar by name, creating it if it does not
+   * already exist.
+   * 
+   * @param {string} name Name of the progress bar.
+   */
+  constructor(name) {
+    if (Progress.progressBars[name]) {
+      return Progress.progressBars[name];
+    }
+
+    this.attached = false;
+    this.formatter = value => value.toString();
+    this.name = name;
+    
+    Progress.progressBars[name] = this;
+  }
+
+  _updateLabel() {
+    // Cast to string before setting.
+    this._progress.attr("aria-valuenow", String(this.value));
+    this._progress.attr("aria-valuemax", String(this.max));
+    this._progressLabel.text(`${this.formattedValue()} of ${this.formattedMax()}`);
+  }
+
+  _updateView() {
+    this._progressBar.css("width", `${(this.position * 100).toFixed(2)}%`);
+  }
+
+  /**
+   * Only construct the DOM tree when it is accessed.
+   */
+  get domTree() {
+    if (!this._progress) {
+      // Only the container should be visible to ARIA. The contents should be
+      // hidden from assistive technologies.
+      const container = $(`<div></div>`)
+        .attr("id", `progress-${this.name}`)
+        .attr("role", "progressbar")
+        .attr("aria-valuemin", "0")
+        .attr("aria-valuetext", "Downloading...")
+        .addClass("progress-bar");
+  
+      const bar = $(`<div></div>`)
+        .attr("id", `progress-${this.name}-bar`)
+        .attr("aria-hidden", "true")
+        .addClass("progress-inner")
+        .appendTo(container);
+
+      const label = $(`<span></span>`)
+        .attr("id", `progress-${this.name}-label`)
+        .attr("aria-hidden", "true")
+        .addClass("progress-label")
+        .appendTo(container);
+
+      this._progress = container;
+      this._progressBar = bar;
+      this._progressLabel = label;
+    }
+
+    return this._progress.get(0);
+  }
+
+  /** @type {number} */
+  get max() {
+    if (!("_max" in this)) {
+      return 0;
+    }
+
+    return this._max;
+  }
+
+  set max(number) {
+    this._max = number;
+    this._updateLabel();
+  }
+
+  get position() {
+    return this.value / this.max;
+  }
+
+  /** @type {number} */
+  get value() {
+    return this._value;
+  }
+
+  set value(number) {
+    // Clamp the value to prevent overflow.
+    this._value = Math.min(number, this.max);
+    this._updateView();
+    this._updateLabel();
+  }
+
+  /**
+   * `formattedMax :: () -> Any`
+   * 
+   * Transform the maximum progress using a custom format function, and return
+   * the result.
+   * 
+   * @returns {any} The result of executing the formatter against `this.value`.
+   */
+
+  formattedMax() {
+    return this.formatter(this.max);
+  }
+
+  /**
+   * `formattedValue :: () -> Any`
+   * 
+   * Transform the current progress using a custom format function, and return
+   * the result.
+   * 
+   * @returns {any} The result of executing the formatter against `this.value`.
+   */
+  formattedValue() {
+    return this.formatter(this.value);
+  }
+
+  /**
+   * `render :: HTMLElement -> ()`
+   * 
+   * Render the progress bar in an element. Triggers the DOM tree build, if not
+   * already performed.
+   * 
+   * @param {HTMLElement} base Where to render this progress bar.
+   */
+  render(base) {
+    base.append(this.domTree);
+  }
+}
+
+exports.Progress = function(name) {
+  return new Progress(name);
+}

--- a/progress.js
+++ b/progress.js
@@ -4,136 +4,136 @@
  * Helper class for dealing with HTML progress bars.
  */
 class Progress {
-	/**
-	 * `Progress :: String -> Progress`
-	 * 
-	 * Get a reference to a progress bar by name, creating it if it does not
-	 * already exist.
-	 * 
-	 * @param {string} name Name of the progress bar.
-	 */
-	constructor(name) {
-		if (Progress.progressBars[name]) {
-			return Progress.progressBars[name];
-		}
+    /**
+     * `Progress :: String -> Progress`
+     *
+     * Get a reference to a progress bar by name, creating it if it does not
+     * already exist.
+     *
+     * @param {string} name Name of the progress bar.
+     */
+    constructor(name) {
+        if (Progress.progressBars[name]) {
+            return Progress.progressBars[name];
+        }
 
-		this.attached = false;
-		this.formatter = value => value.toString();
-		this.name = name;
+        this.attached = false;
+        this.formatter = (value) => value.toString();
+        this.name = name;
 
-		Progress.progressBars[name] = this;
-	}
+        Progress.progressBars[name] = this;
+    }
 
-	_updateLabel() {
-		// Cast to string before setting.
-		this._progress.attr("aria-valuenow", String(this.value));
-		this._progress.attr("aria-valuemax", String(this.max));
-		this._progressLabel.text(`${this.formattedValue()} of ${this.formattedMax()}`);
-	}
+    _updateLabel() {
+        // Cast to string before setting.
+        this._progress.attr("aria-valuenow", String(this.value));
+        this._progress.attr("aria-valuemax", String(this.max));
+        this._progressLabel.text(`${this.formattedValue()} of ${this.formattedMax()}`);
+    }
 
-	_updateView() {
-		this._progressBar.css("width", `${(this.position * 100).toFixed(2)}%`);
-	}
+    _updateView() {
+        this._progressBar.css("width", `${(this.position * 100).toFixed(2)}%`);
+    }
 
-	/**
-	 * Only construct the DOM tree when it is accessed.
-	 */
-	get domTree() {
-		if (!this._progress) {
-			// Only the container should be visible to ARIA. The contents should be
-			// hidden from assistive technologies.
-			const container = $(`<div></div>`)
-				.attr("id", `progress-${this.name}`)
-				.attr("role", "progressbar")
-				.attr("aria-valuemin", "0")
-				.attr("aria-valuetext", "Downloading...")
-				.addClass("progress-bar");
+    /**
+     * Only construct the DOM tree when it is accessed.
+     */
+    get domTree() {
+        if (!this._progress) {
+            // Only the container should be visible to ARIA. The contents should be
+            // hidden from assistive technologies.
+            const container = $("<div></div>").
+                attr("id", `progress-${this.name}`).
+                attr("role", "progressbar").
+                attr("aria-valuemin", "0").
+                attr("aria-valuetext", "Downloading...").
+                addClass("progress-bar");
 
-			const bar = $(`<div></div>`)
-				.attr("id", `progress-${this.name}-bar`)
-				.attr("aria-hidden", "true")
-				.addClass("progress-inner")
-                .appendTo(container);
+            const bar = $("<div></div>").
+                attr("id", `progress-${this.name}-bar`).
+                attr("aria-hidden", "true").
+                addClass("progress-inner").
+                appendTo(container);
 
-			const label = $(`<span></span>`)
-				.attr("id", `progress-${this.name}-label`)
-				.attr("aria-hidden", "true")
-				.addClass("progress-label")
-				.appendTo(container);
+            const label = $("<span></span>").
+                attr("id", `progress-${this.name}-label`).
+                attr("aria-hidden", "true").
+                addClass("progress-label").
+                appendTo(container);
 
-			this._progress = container;
-			this._progressBar = bar;
-			this._progressLabel = label;
-		}
+            this._progress = container;
+            this._progressBar = bar;
+            this._progressLabel = label;
+        }
 
-		return this._progress.get(0);
-	}
+        return this._progress.get(0);
+    }
 
-	/** @type {number} */
-	get max() {
-		if (!("_max" in this)) {
-			return 0;
-		}
+    /** @type {number} */
+    get max() {
+        if (!("_max" in this)) {
+            return 0;
+        }
 
-		return this._max;
-	}
+        return this._max;
+    }
 
-	set max(number) {
-		this._max = number;
-		this._updateLabel();
-	}
+    set max(number) {
+        this._max = number;
+        this._updateLabel();
+    }
 
-	get position() {
-		return this.value / this.max;
-	}
+    get position() {
+        return this.value / this.max;
+    }
 
-	/** @type {number} */
-	get value() {
-		return this._value;
-	}
+    /** @type {number} */
+    get value() {
+        return this._value;
+    }
 
-	set value(number) {
-		// Clamp the value to prevent overflow.
-		this._value = Math.min(number, this.max);
-		this._updateView();
-		this._updateLabel();
-	}
+    set value(number) {
+        // Clamp the value to prevent overflow.
+        this._value = Math.min(number, this.max);
+        this._updateView();
+        this._updateLabel();
+    }
 
-	/**
-	 * `formattedMax :: () -> Any`
-	 * 
-	 * Transform the maximum progress using a custom format function, and return
-	 * the result.
-	 * 
-	 * @returns {any} The result of executing the formatter against `this.value`.
-	 */
-	formattedMax() {
-		return this.formatter(this.max);
-	}
+    /**
+     * `formattedMax :: () -> Any`
+     *
+     * Transform the maximum progress using a custom format function, and return
+     * the result.
+     *
+     * @returns {any} The result of executing the formatter against `this.value`.
+     */
+    formattedMax() {
+        return this.formatter(this.max);
+    }
 
-	/**
-	 * `formattedValue :: () -> Any`
-	 * 
-	 * Transform the current progress using a custom format function, and return
-	 * the result.
-	 * 
-	 * @returns {any} The result of executing the formatter against `this.value`.
-	 */
-	formattedValue() {
-		return this.formatter(this.value);
-	}
+    /**
+     * `formattedValue :: () -> Any`
+     *
+     * Transform the current progress using a custom format function, and return
+     * the result.
+     *
+     * @returns {any} The result of executing the formatter against `this.value`.
+     */
+    formattedValue() {
+        return this.formatter(this.value);
+    }
 
-	/**
-	 * `render :: HTMLElement -> ()`
-	 * 
-	 * Render the progress bar in an element. Triggers the DOM tree build, if not
-	 * already performed.
-	 * 
-	 * @param {HTMLElement} base Where to render this progress bar.
-	 */
-	render(base) {
-		base.append(this.domTree);
-	}
+    /**
+     * `render :: HTMLElement -> ()`
+     *
+     * Render the progress bar in an element. Triggers the DOM tree build, if not
+     * already performed.
+     *
+     * @param {HTMLElement} base Where to render this progress bar.
+     */
+    render(base) {
+        base.append(this.domTree);
+    }
 }
 
 // We don't have to keep a permanent reference to the progress bar that we want;
@@ -142,5 +142,5 @@ class Progress {
 Progress.progressBars = {};
 
 exports.Progress = function(name) {
-	return new Progress(name);
-}
+    return new Progress(name);
+};

--- a/progress.js
+++ b/progress.js
@@ -2,144 +2,144 @@
  * Helper class for dealing with HTML progress bars.
  */
 class Progress {
-  // We don't have to keep a permanent reference to the progress bar that we
-  // want; we can just run the constructor with the same name to get the same
-  // object out.
-  static progressBars = {};
+	// We don't have to keep a permanent reference to the progress bar that we
+	// want; we can just run the constructor with the same name to get the same
+	// object out.
+	static progressBars = {};
 
-  /**
-   * `Progress :: String -> Progress`
-   * 
-   * Get a reference to a progress bar by name, creating it if it does not
-   * already exist.
-   * 
-   * @param {string} name Name of the progress bar.
-   */
-  constructor(name) {
-    if (Progress.progressBars[name]) {
-      return Progress.progressBars[name];
-    }
+	/**
+	 * `Progress :: String -> Progress`
+	 * 
+	 * Get a reference to a progress bar by name, creating it if it does not
+	 * already exist.
+	 * 
+	 * @param {string} name Name of the progress bar.
+	 */
+	constructor(name) {
+		if (Progress.progressBars[name]) {
+			return Progress.progressBars[name];
+		}
 
-    this.attached = false;
-    this.formatter = value => value.toString();
-    this.name = name;
-    
-    Progress.progressBars[name] = this;
-  }
+		this.attached = false;
+		this.formatter = value => value.toString();
+		this.name = name;
+		
+		Progress.progressBars[name] = this;
+	}
 
-  _updateLabel() {
-    // Cast to string before setting.
-    this._progress.attr("aria-valuenow", String(this.value));
-    this._progress.attr("aria-valuemax", String(this.max));
-    this._progressLabel.text(`${this.formattedValue()} of ${this.formattedMax()}`);
-  }
+	_updateLabel() {
+		// Cast to string before setting.
+		this._progress.attr("aria-valuenow", String(this.value));
+		this._progress.attr("aria-valuemax", String(this.max));
+		this._progressLabel.text(`${this.formattedValue()} of ${this.formattedMax()}`);
+	}
 
-  _updateView() {
-    this._progressBar.css("width", `${(this.position * 100).toFixed(2)}%`);
-  }
+	_updateView() {
+		this._progressBar.css("width", `${(this.position * 100).toFixed(2)}%`);
+	}
 
-  /**
-   * Only construct the DOM tree when it is accessed.
-   */
-  get domTree() {
-    if (!this._progress) {
-      // Only the container should be visible to ARIA. The contents should be
-      // hidden from assistive technologies.
-      const container = $(`<div></div>`)
-        .attr("id", `progress-${this.name}`)
-        .attr("role", "progressbar")
-        .attr("aria-valuemin", "0")
-        .attr("aria-valuetext", "Downloading...")
-        .addClass("progress-bar");
-  
-      const bar = $(`<div></div>`)
-        .attr("id", `progress-${this.name}-bar`)
-        .attr("aria-hidden", "true")
-        .addClass("progress-inner")
-        .appendTo(container);
+	/**
+	 * Only construct the DOM tree when it is accessed.
+	 */
+	get domTree() {
+		if (!this._progress) {
+			// Only the container should be visible to ARIA. The contents should be
+			// hidden from assistive technologies.
+			const container = $(`<div></div>`)
+				.attr("id", `progress-${this.name}`)
+				.attr("role", "progressbar")
+				.attr("aria-valuemin", "0")
+				.attr("aria-valuetext", "Downloading...")
+				.addClass("progress-bar");
+	
+			const bar = $(`<div></div>`)
+				.attr("id", `progress-${this.name}-bar`)
+				.attr("aria-hidden", "true")
+				.addClass("progress-inner")
+				.appendTo(container);
 
-      const label = $(`<span></span>`)
-        .attr("id", `progress-${this.name}-label`)
-        .attr("aria-hidden", "true")
-        .addClass("progress-label")
-        .appendTo(container);
+			const label = $(`<span></span>`)
+				.attr("id", `progress-${this.name}-label`)
+				.attr("aria-hidden", "true")
+				.addClass("progress-label")
+				.appendTo(container);
 
-      this._progress = container;
-      this._progressBar = bar;
-      this._progressLabel = label;
-    }
+			this._progress = container;
+			this._progressBar = bar;
+			this._progressLabel = label;
+		}
 
-    return this._progress.get(0);
-  }
+		return this._progress.get(0);
+	}
 
-  /** @type {number} */
-  get max() {
-    if (!("_max" in this)) {
-      return 0;
-    }
+	/** @type {number} */
+	get max() {
+		if (!("_max" in this)) {
+			return 0;
+		}
 
-    return this._max;
-  }
+		return this._max;
+	}
 
-  set max(number) {
-    this._max = number;
-    this._updateLabel();
-  }
+	set max(number) {
+		this._max = number;
+		this._updateLabel();
+	}
 
-  get position() {
-    return this.value / this.max;
-  }
+	get position() {
+		return this.value / this.max;
+	}
 
-  /** @type {number} */
-  get value() {
-    return this._value;
-  }
+	/** @type {number} */
+	get value() {
+		return this._value;
+	}
 
-  set value(number) {
-    // Clamp the value to prevent overflow.
-    this._value = Math.min(number, this.max);
-    this._updateView();
-    this._updateLabel();
-  }
+	set value(number) {
+		// Clamp the value to prevent overflow.
+		this._value = Math.min(number, this.max);
+		this._updateView();
+		this._updateLabel();
+	}
 
-  /**
-   * `formattedMax :: () -> Any`
-   * 
-   * Transform the maximum progress using a custom format function, and return
-   * the result.
-   * 
-   * @returns {any} The result of executing the formatter against `this.value`.
-   */
+	/**
+	 * `formattedMax :: () -> Any`
+	 * 
+	 * Transform the maximum progress using a custom format function, and return
+	 * the result.
+	 * 
+	 * @returns {any} The result of executing the formatter against `this.value`.
+	 */
 
-  formattedMax() {
-    return this.formatter(this.max);
-  }
+	formattedMax() {
+		return this.formatter(this.max);
+	}
 
-  /**
-   * `formattedValue :: () -> Any`
-   * 
-   * Transform the current progress using a custom format function, and return
-   * the result.
-   * 
-   * @returns {any} The result of executing the formatter against `this.value`.
-   */
-  formattedValue() {
-    return this.formatter(this.value);
-  }
+	/**
+	 * `formattedValue :: () -> Any`
+	 * 
+	 * Transform the current progress using a custom format function, and return
+	 * the result.
+	 * 
+	 * @returns {any} The result of executing the formatter against `this.value`.
+	 */
+	formattedValue() {
+		return this.formatter(this.value);
+	}
 
-  /**
-   * `render :: HTMLElement -> ()`
-   * 
-   * Render the progress bar in an element. Triggers the DOM tree build, if not
-   * already performed.
-   * 
-   * @param {HTMLElement} base Where to render this progress bar.
-   */
-  render(base) {
-    base.append(this.domTree);
-  }
+	/**
+	 * `render :: HTMLElement -> ()`
+	 * 
+	 * Render the progress bar in an element. Triggers the DOM tree build, if not
+	 * already performed.
+	 * 
+	 * @param {HTMLElement} base Where to render this progress bar.
+	 */
+	render(base) {
+		base.append(this.domTree);
+	}
 }
 
 exports.Progress = function(name) {
-  return new Progress(name);
+	return new Progress(name);
 }

--- a/progress.js
+++ b/progress.js
@@ -4,11 +4,6 @@
  * Helper class for dealing with HTML progress bars.
  */
 class Progress {
-	// We don't have to keep a permanent reference to the progress bar that we
-	// want; we can just run the constructor with the same name to get the same
-	// object out.
-	static progressBars = {};
-
 	/**
 	 * `Progress :: String -> Progress`
 	 * 
@@ -140,6 +135,11 @@ class Progress {
 		base.append(this.domTree);
 	}
 }
+
+// We don't have to keep a permanent reference to the progress bar that we want;
+// we can just run the constructor with the same name to get the same object
+// out.
+Progress.progressBars = {};
 
 exports.Progress = function(name) {
 	return new Progress(name);

--- a/progress.js
+++ b/progress.js
@@ -25,7 +25,7 @@ class Progress {
 		this.attached = false;
 		this.formatter = value => value.toString();
 		this.name = name;
-		
+
 		Progress.progressBars[name] = this;
 	}
 
@@ -53,12 +53,12 @@ class Progress {
 				.attr("aria-valuemin", "0")
 				.attr("aria-valuetext", "Downloading...")
 				.addClass("progress-bar");
-	
+
 			const bar = $(`<div></div>`)
 				.attr("id", `progress-${this.name}-bar`)
 				.attr("aria-hidden", "true")
 				.addClass("progress-inner")
-				.appendTo(container);
+                .appendTo(container);
 
 			const label = $(`<span></span>`)
 				.attr("id", `progress-${this.name}-label`)
@@ -112,7 +112,6 @@ class Progress {
 	 * 
 	 * @returns {any} The result of executing the formatter against `this.value`.
 	 */
-
 	formattedMax() {
 		return this.formatter(this.max);
 	}

--- a/progress.js
+++ b/progress.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /**
  * Helper class for dealing with HTML progress bars.
  */

--- a/renderer.js
+++ b/renderer.js
@@ -22,6 +22,7 @@ const versionInfo = require("./version_info");
 const retrieveNews = require("./retrieve_news");
 const errorSuggestions = require("./error_suggestions");
 const {Modal, ComboBox, showGenericError} = require("./modal");
+const {Progress} = require("./progress");
 const {unpackRelease, findBinInRelease} = require("./unpack");
 const {formatBytes} = require("./utils");
 

--- a/renderer.js
+++ b/renderer.js
@@ -160,6 +160,9 @@ function getLauncherKey(){
 // save-it-and-show-download-progress (note: link split on two lines)
 // With some modifications
 function downloadFile(configuration){
+    const downloadProgress = Progress("download");
+    downloadProgress.formatter = formatBytes;
+
     return new Promise(function(resolve, reject){
         // Save variable to know progress
         let received_bytes = 0;
@@ -181,6 +184,7 @@ function downloadFile(configuration){
         req.on("response", function ( data ) {
             // Change the total bytes value to get progress later.
             total_bytes = parseInt(data.headers["content-length"]);
+            downloadProgress.max = total_bytes;
 
             contentType = data.headers["content-type"];
         });
@@ -986,14 +990,16 @@ function playPressed(){
 
         }
 
+        const downloadProgress = Progress("download");
+        const status = document.getElementById("dlProgress");
+        downloadProgress.render(status);
+
         const dlFailCallback = (error) => {
 
             if(fs.existsSync(localTarget)){
 
                 fs.unlinkSync(localTarget);
             }
-
-            const status = document.getElementById("dlProgress");
 
             if(status){
 
@@ -1005,16 +1011,8 @@ function playPressed(){
             remoteFile: download.url,
             localFile: localTarget,
 
-            onProgress: function (received, total){
-
-                const percentage = (received * 100) / total;
-                const status = document.getElementById("dlProgress");
-
-                if(status){
-
-                    status.textContent = percentage.toFixed(2) + "% | " + received +
-                        " bytes out of " + total + " bytes.";
-                }
+            onProgress: function (received){
+                downloadProgress.value = received;
             }
         };
 

--- a/renderer.js
+++ b/renderer.js
@@ -23,6 +23,7 @@ const retrieveNews = require("./retrieve_news");
 const errorSuggestions = require("./error_suggestions");
 const {Modal, ComboBox, showGenericError} = require("./modal");
 const {unpackRelease, findBinInRelease} = require("./unpack");
+const {formatBytes} = require("./utils");
 
 const openpgp = require("openpgp");
 

--- a/thrive.css
+++ b/thrive.css
@@ -547,7 +547,7 @@ input[type="text"].Report {
 }
 
 .progress-bar {
-  --color: #000000;
+  --color: #000;
 
   border: var(--color) solid 2px;
   box-sizing: border-box;
@@ -563,7 +563,7 @@ input[type="text"].Report {
 }
 
 .progress-bar .progress-label {
-  color: #ffffff;
+  color: #fff;
   left: 0;
   mix-blend-mode: difference; /* From https://css-tricks.com/methods-contrasting-text-backgrounds/ */
   padding: 4px 5px;

--- a/thrive.css
+++ b/thrive.css
@@ -545,3 +545,28 @@ input[type="text"].Report {
   visibility: visible;
   opacity: 1;
 }
+
+.progress-bar {
+  --color: #000000;
+
+  border: var(--color) solid 2px;
+  box-sizing: border-box;
+  padding: 2px;
+  position: relative;
+}
+
+.progress-bar .progress-inner {
+  background-color: var(--color);
+  box-sizing: border-box;
+  height: 23px;
+  width: 0;
+}
+
+.progress-bar .progress-label {
+  color: #ffffff;
+  left: 0;
+  mix-blend-mode: difference; /* From https://css-tricks.com/methods-contrasting-text-backgrounds/ */
+  padding: 4px 5px;
+  position: absolute;
+  top: 0;
+}

--- a/utils.js
+++ b/utils.js
@@ -7,12 +7,12 @@
  * @param {string | number} bytes 
  */
 function formatBytes(bytes, precision = 2) {
-	const units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
-	const kb = 1024;
+    const units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+    const kb = 1024;
 
-	if (bytes == 0) {
-		return "0 B";
-	}
+    if (bytes == 0) {
+        return "0 B";
+    }
 
     const unit = Math.floor(Math.log(Number(bytes)) / Math.log(kb));
     

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,19 @@
+// Implementation taken from https://stackoverflow.com/a/18650828/9277476.
+/**
+ * Convert a raw number of bytes into a human-readable notation.
+ * 
+ * @param {string | number} bytes 
+ */
+function formatBytes(bytes, precision = 2) {
+  const units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+  const kb = 1024;
+
+  if (bytes == 0) {
+    return "0 B";
+  }
+
+  const unit = Math.floor(Math.log(Number(bytes)) / Math.log(kb));
+  return (Number(bytes) / Math.pow(kb, unit)).toFixed(Math.max(precision, 0)) + " " + units[unit];
+}
+
+exports.formatBytes = formatBytes;

--- a/utils.js
+++ b/utils.js
@@ -4,7 +4,7 @@
 /**
  * Convert a raw number of bytes into a human-readable notation.
  *
- * @param {string | number} bytes 
+ * @param {string | number} bytes
  */
 function formatBytes(bytes, precision = 2) {
     const units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
@@ -15,9 +15,9 @@ function formatBytes(bytes, precision = 2) {
     }
 
     const unit = Math.floor(Math.log(Number(bytes)) / Math.log(kb));
-    
-    return (Number(bytes) / Math.pow(kb, unit))
-        .toFixed(Math.max(precision, 0)) + " " + units[unit];
+
+    return (Number(bytes) / Math.pow(kb, unit)).
+        toFixed(Math.max(precision, 0)) + " " + units[unit];
 }
 
 exports.formatBytes = formatBytes;

--- a/utils.js
+++ b/utils.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Implementation taken from https://stackoverflow.com/a/18650828/9277476.
 /**
  * Convert a raw number of bytes into a human-readable notation.

--- a/utils.js
+++ b/utils.js
@@ -1,19 +1,21 @@
 // Implementation taken from https://stackoverflow.com/a/18650828/9277476.
 /**
  * Convert a raw number of bytes into a human-readable notation.
- * 
+ *
  * @param {string | number} bytes 
  */
 function formatBytes(bytes, precision = 2) {
-  const units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
-  const kb = 1024;
+	const units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+	const kb = 1024;
 
-  if (bytes == 0) {
-    return "0 B";
-  }
+	if (bytes == 0) {
+		return "0 B";
+	}
 
-  const unit = Math.floor(Math.log(Number(bytes)) / Math.log(kb));
-  return (Number(bytes) / Math.pow(kb, unit)).toFixed(Math.max(precision, 0)) + " " + units[unit];
+    const unit = Math.floor(Math.log(Number(bytes)) / Math.log(kb));
+    
+    return (Number(bytes) / Math.pow(kb, unit))
+        .toFixed(Math.max(precision, 0)) + " " + units[unit];
 }
 
 exports.formatBytes = formatBytes;


### PR DESCRIPTION
As stated in #36 the current status display is not very intuitive for users, and can make it difficult for them to estimate how long the download is going to take. I have replaced this status display with a basic progress bar that shows these values in a more human-readable manner, along with letting them see at a glance how much has been downloaded.

The styles for the progress bar begin at line 549 of `thrive.css`.

Altered functions:
- `downloadFile`, line 162 of renderer.js
- Anonymous function passed to `req.on`, line 184 of renderer.js
- Anonymous function passed to `mkdirp`, line 983 of renderer.js
- `dataObj.onProgress`, line 1014 of renderer.js

fixes #36 