### PR TITLE
Fix mkdirp error handling

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -980,11 +980,14 @@ function playPressed(){
     }
 
     const status = document.getElementById("dlProgress");
-
-    mkdirp(tmpDLFolder).catch((err) =>{
+    const mkdir = mkdirp(tmpDLFolder);
+    
+    mkdir.catch((err) =>{
         console.error(err);
         alert("failed to create dl directory");
-    }).then(() => {
+    });
+    
+    mkdir.then(() => {
         const downloadProgress = Progress("download");
         downloadProgress.render(status);
 

--- a/renderer.js
+++ b/renderer.js
@@ -912,11 +912,15 @@ function onDLFileReady(version, download, fileName){
     // Destroy the download progress indicator
     status.innerHTML = "";
 
+    const mkdir = mkdirp(settings.installPath);
+
     // If unpacked already launch Thrive //
-    mkdirp(settings.installPath).catch((err) =>{
+    mkdir.catch((err) =>{
         console.error(err);
         alert("failed to create install directory");
-    }).then(function(){
+    });
+
+    mkdir.then(function(){
         // Check does it exist //
         if(fs.existsSync(path.join(settings.installPath, download.folderName))){
             console.log("archive has already been extracted");
@@ -981,12 +985,12 @@ function playPressed(){
 
     const status = document.getElementById("dlProgress");
     const mkdir = mkdirp(tmpDLFolder);
-    
+
     mkdir.catch((err) =>{
         console.error(err);
         alert("failed to create dl directory");
     });
-    
+
     mkdir.then(() => {
         const downloadProgress = Progress("download");
         downloadProgress.render(status);


### PR DESCRIPTION
The `catch(handler)` function on a Promise object does not end the promise chain: it internally calls `then(undefined, handler)` which returns a Promise of its own that will call its own `then` handler(s) when the previous handlers finish executing. This means that code further along the chain would continue to execute even if the download directory was unable to be created - possibly resulting in a launcher crash. See [the Mozilla documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch) for details. [This StackOverflow answer](https://stackoverflow.com/a/24619782/9277476) also describes the problem and how to fix it.

This can be fixed by separating the `catch` and `then` blocks into their own separate method calls, which creates a separate chain where there is nothing else to do after the catch block executes, halting execution there.