### PR TITLE
formatBytes fix

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,7 @@ function formatBytes(bytes, precision = 2){
     const units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
     const kb = 1024;
 
-    if(bytes == 0){
+    if(bytes == 0 || isNaN(bytes)){
         return "0 B";
     }
 


### PR DESCRIPTION
I downloaded launcher and just bumped in a little bug, seeing "NaN Undefined of 187.08 MiB" for a moment and it became normal "0 B of 187.08 MiB". So here's a possible fix