### PR TITLE
Clean up launching popup's inline CSS

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -121,7 +121,7 @@
 
     <!-- Popup Launching window -->
     <div id="playModal" class="modal">
-      <div id="playModalDialog" class="modal-content" style="max-height: 80%;">
+      <div id="playModalDialog" class="modal-content">
         <span id="playModalClose" class="close">&times;</span>
         <div id="playModalContent">An unknown error happened</div>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -121,8 +121,7 @@
 
     <!-- Popup Launching window -->
     <div id="playModal" class="modal">
-      <div id="playModalDialog" class="modal-content" style="position: absolute; margin-top: auto; max-height: 500px; width: 650px; max-width: 650px;
-                                                            margin: 0; margin-top:25px; top: 15%; left: 50%; transform: translateX(-50%) translateY(-14%); overflow: hidden;">
+      <div id="playModalDialog" class="modal-content" style="max-height: 80%;">
         <span id="playModalClose" class="close">&times;</span>
         <div id="playModalContent">An unknown error happened</div>
       </div>

--- a/src/main.js
+++ b/src/main.js
@@ -187,7 +187,7 @@ function createWindow(){
 
     // Create the browser window.
     mainWindow = new BrowserWindow({
-        width: 950 + (openDev ? 700 : 0), height: 652,
+        width: 950 + (openDev ? 700 : 0), height: 625,
 
         // No default titlebar, we use a custom one (except when using devtools)
         frame: openDev,

--- a/src/main.js
+++ b/src/main.js
@@ -187,7 +187,7 @@ function createWindow(){
 
     // Create the browser window.
     mainWindow = new BrowserWindow({
-        width: 950 + (openDev ? 700 : 0), height: 625,
+        width: 950 + (openDev ? 700 : 0), height: 652,
 
         // No default titlebar, we use a custom one (except when using devtools)
         frame: openDev,

--- a/src/thrive.css
+++ b/src/thrive.css
@@ -432,6 +432,21 @@ img.TopLogo {
   /* animation-duration: 0.4s */
 }
 
+#playModalDialog {
+  /* Make the play popup's position and size fixed */
+  position: absolute;
+  margin-top: auto;
+  max-height: 500px;
+  width: 650px;
+  max-width: 650px;
+  margin: 0;
+  margin-top: 25px;
+  top: 5%;
+  left: 50%;
+  transform: translateX(-50%);
+  overflow: hidden;
+}
+
 #playModalContent {
   min-height: 500px;
   max-height: 500px;

--- a/src/thrive.css
+++ b/src/thrive.css
@@ -435,11 +435,9 @@ img.TopLogo {
 #playModalDialog {
   /* Make the play popup's position and size fixed */
   position: absolute;
-  margin-top: auto;
   max-height: 500px;
   width: 650px;
   max-width: 650px;
-  margin: 0;
   margin-top: 25px;
   top: 5%;
   left: 50%;


### PR DESCRIPTION
~Originally added the overly complicated inline css so the popup's height can automatically resize depending on the window's height, but it ended up being a mess. The popup seem to also have a different/broken closing animation as a result. So I now simplified it to just set a maximum height to make it consistent with some other popups, in another note I also slightly increased the Thrive launcher's window a bit to get an extra bottom margin for the now no longer resizing launching popup~.

Moved the inline css into the separate css file and with tweaks so the popup slide up animation looks correct.