### PR TITLE
Use semver for dropdown

### DIFF
--- a/src/version_select_button.js
+++ b/src/version_select_button.js
@@ -2,6 +2,7 @@
 "use strict";
 
 const log = require("electron-log");
+const semver = require("semver");
 
 const {assert} = require("./utils");
 const {getCurrentlySelected, setCurrentlySelectedVersion} = require("./remembered_version");
@@ -215,11 +216,10 @@ function refreshVersionList(){
 
     // Sort the versions //
     playComboAllChoices.sort(function(a, b){
-        // TODO: could use semver here (probably)
-        if(a.version.releaseNum < b.version.releaseNum)
-            return 1;
-        if(a.version.releaseNum > b.version.releaseNum)
-            return -1;
+        // https://stackoverflow.com/a/55466325
+        const cmp = a.version.releaseNum.localeCompare(b.version.releaseNum, undefined, { numeric: true });
+        if (cmp !== 0)
+            return -cmp
 
         return a.download.os < b.download.os;
     });

--- a/src/version_select_button.js
+++ b/src/version_select_button.js
@@ -216,9 +216,14 @@ function refreshVersionList(){
     // Sort the versions //
     playComboAllChoices.sort(function(a, b){
         // https://stackoverflow.com/a/55466325
-        const cmp = a.version.releaseNum.localeCompare(b.version.releaseNum, undefined, { numeric: true });
-        if (cmp !== 0)
-            return -cmp
+        const cmp = a.version.releaseNum.localeCompare(
+            b.version.releaseNum,
+            undefined,
+            {numeric: true}
+        );
+
+        if(cmp !== 0)
+            return -cmp;
 
         return a.download.os < b.download.os;
     });

--- a/src/version_select_button.js
+++ b/src/version_select_button.js
@@ -217,7 +217,7 @@ function refreshVersionList(){
     playComboAllChoices.sort(function(a, b){
         // https://stackoverflow.com/a/55466325
         const cmp = a.version.releaseNum.localeCompare(b.version.releaseNum, undefined, {
-            numeric: true
+            numeric: true,
         });
 
         if(cmp !== 0)

--- a/src/version_select_button.js
+++ b/src/version_select_button.js
@@ -2,7 +2,6 @@
 "use strict";
 
 const log = require("electron-log");
-const semver = require("semver");
 
 const {assert} = require("./utils");
 const {getCurrentlySelected, setCurrentlySelectedVersion} = require("./remembered_version");

--- a/src/version_select_button.js
+++ b/src/version_select_button.js
@@ -216,11 +216,8 @@ function refreshVersionList(){
     // Sort the versions //
     playComboAllChoices.sort(function(a, b){
         // https://stackoverflow.com/a/55466325
-        const cmp = a.version.releaseNum.localeCompare(
-            b.version.releaseNum,
-            undefined,
-            {numeric: true}
-        );
+        const cmp = a.version.releaseNum
+            .localeCompare(b.version.releaseNum, undefined, {numeric: true});
 
         if(cmp !== 0)
             return -cmp;

--- a/src/version_select_button.js
+++ b/src/version_select_button.js
@@ -216,8 +216,9 @@ function refreshVersionList(){
     // Sort the versions //
     playComboAllChoices.sort(function(a, b){
         // https://stackoverflow.com/a/55466325
-        const cmp = a.version.releaseNum
-            .localeCompare(b.version.releaseNum, undefined, {numeric: true});
+        const cmp = a.version.releaseNum.localeCompare(b.version.releaseNum, undefined, {
+            numeric: true
+        });
 
         if(cmp !== 0)
             return -cmp;


### PR DESCRIPTION
Fixes #166. 

Not using `node-semver` because it doesn't support four component versions (`0.5.8.1`).

Left: Before
Right: After
![Comparison](https://user-images.githubusercontent.com/39150378/201815397-342358b4-1691-458a-a601-cc38c7d6a4ae.png)
